### PR TITLE
libfitbit should put tracker to sleep after sync

### DIFF
--- a/python/fitbit.py
+++ b/python/fitbit.py
@@ -181,6 +181,9 @@ class FitBit(object):
         # 0x78 0x01 is apparently the device reset command
         self.base.send_acknowledged_data([0x78, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00])
 
+    def command_sleep(self):
+        self.base.send_acknowledged_data([0x7f, 0x03, 0x00, 0x00, 0x00, 0x00, 0x00, 0x3c])
+
     def wait_for_beacon(self):
         # FitBit device initialization
         print "Waiting for receive"

--- a/python/fitbit_client.py
+++ b/python/fitbit_client.py
@@ -140,6 +140,7 @@ class FitBitClient(object):
             else:
                 print "No URL returned. Quitting."
                 break
+        self.fitbit.command_sleep()
         self.fitbit.base.close()
 
 def main():


### PR DESCRIPTION
From reading the logs on windows it appears that the windows client sends a final command at the end to put the tracker to sleep for the 15 minute sync interval.  This change appears to have the desired effect of making libfitbit do the same.
